### PR TITLE
bdd-test-angular-io-quickstart-1530532896 to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: bdd-test-python-http-1530532897
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: bdd-test-angular-io-quickstart-1530532896
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote bdd-test-angular-io-quickstart-1530532896 to version 0.0.1