### PR TITLE
bdd-test-angular-io-quickstart-1530536708 to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,3 +16,6 @@ dependencies:
 - name: bdd-test-python-http-1530536708
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1
+- name: bdd-test-angular-io-quickstart-1530536708
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1


### PR DESCRIPTION
Promote bdd-test-angular-io-quickstart-1530536708 to version 0.0.1